### PR TITLE
implement kube authenticator

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 # Ignore build and test binaries.
 bin/
 !bin/manager
+!bin/kube-authenticator

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,6 +9,9 @@ issues:
   # restore some of the defaults
   # (fill in the rest as needed)
   exclude-rules:
+    - path: "cmd/*"
+      linters:
+        - lll
     - path: "api/*"
       linters:
         - lll

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ REGISTRY ?= ghcr.io/funccloud/fcp
 # Default Version
 VERSION ?= latest
 # List of applications
-APPS := manager
+APPS := manager kube-authenticator
 # Default App Name (used if APP is not specified, e.g., in deploy or run)
 APP ?= manager
 

--- a/Tiltfile
+++ b/Tiltfile
@@ -7,7 +7,7 @@ watch_settings(ignore=['bin'])
 # --- Configuration ---
 REGISTRY = 'ghcr.io/funccloud/fcp' # Or use read_json('tilt_config.json').get('registry', 'default_registry')
 VERSION = 'latest' # Read version from env var, default to latest
-APPS = ['manager']
+APPS = ['manager', 'kube-authenticator'] # List of apps to build
 DEFAULT_APP = 'manager' # App used for single-app commands if needed
 
 # --- Helper Functions ---

--- a/cmd/kube-authenticator/main.go
+++ b/cmd/kube-authenticator/main.go
@@ -58,7 +58,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&secureMetrics, "metrics-secure", true,
 		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
-	flag.StringVar(&webhookCertPath, "webhook-cert-path", "/tmp/kube-apiproxy/certs", "The directory that contains the webhook certificate.")
+	flag.StringVar(&webhookCertPath, "webhook-cert-path", "/tmp/kube-authenticator/certs", "The directory that contains the webhook certificate.")
 	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
 	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
 	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",

--- a/cmd/kube-authenticator/main.go
+++ b/cmd/kube-authenticator/main.go
@@ -49,7 +49,15 @@ func main() {
 	var enableHTTP2 bool
 	var userInfoEndpoint string
 	var tlsOpts []func(*tls.Config)
-	flag.StringVar(&userInfoEndpoint, "userinfo-endpoint", "", "UserInfo endpoint to use for authentication.")
+        flag.StringVar(&userInfoEndpoint, "userinfo-endpoint", "", "UserInfo endpoint to use for authentication.")
+        // Validate userInfoEndpoint
+        if userInfoEndpoint != "" {
+                _, err := url.ParseRequestURI(userInfoEndpoint)
+                if err != nil {
+                        setupLog.Error(err, "invalid userinfo-endpoint")
+                        os.Exit(1)
+                }
+        }
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")

--- a/cmd/kube-authenticator/main.go
+++ b/cmd/kube-authenticator/main.go
@@ -49,15 +49,7 @@ func main() {
 	var enableHTTP2 bool
 	var userInfoEndpoint string
 	var tlsOpts []func(*tls.Config)
-        flag.StringVar(&userInfoEndpoint, "userinfo-endpoint", "", "UserInfo endpoint to use for authentication.")
-        // Validate userInfoEndpoint
-        if userInfoEndpoint != "" {
-                _, err := url.ParseRequestURI(userInfoEndpoint)
-                if err != nil {
-                        setupLog.Error(err, "invalid userinfo-endpoint")
-                        os.Exit(1)
-                }
-        }
+	flag.StringVar(&userInfoEndpoint, "userinfo-endpoint", "", "UserInfo endpoint to use for authentication.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")

--- a/cmd/kube-authenticator/main.go
+++ b/cmd/kube-authenticator/main.go
@@ -49,7 +49,7 @@ func main() {
 	var enableHTTP2 bool
 	var userInfoEndpoint string
 	var tlsOpts []func(*tls.Config)
-	flag.StringVar(&userInfoEndpoint, "userinfo-endpoint", "", "UserInfo endpoint to use for authentication.")
+	flag.StringVar(&userInfoEndpoint, "userinfo-endpoint", os.Getenv("USERINFO_ENDPOINT"), "UserInfo endpoint to use for authentication.")
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")

--- a/cmd/kube-authenticator/main.go
+++ b/cmd/kube-authenticator/main.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/tls"
+	"flag"
+	"os"
+	"path/filepath"
+
+	"go.funccloud.dev/fcp/internal/scheme"
+	"go.funccloud.dev/fcp/internal/webhook/tokenreview"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/certwatcher"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+var (
+	setupLog = ctrl.Log.WithName("setup")
+)
+
+// nolint:gocyclo
+func main() {
+	var metricsAddr string
+	var metricsCertPath, metricsCertName, metricsCertKey string
+	var webhookCertPath, webhookCertName, webhookCertKey string
+	var enableLeaderElection bool
+	var probeAddr string
+	var secureMetrics bool
+	var enableHTTP2 bool
+	var userInfoEndpoint string
+	var tlsOpts []func(*tls.Config)
+	flag.StringVar(&userInfoEndpoint, "userinfo-endpoint", "", "UserInfo endpoint to use for authentication.")
+	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
+		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
+		"Enable leader election for controller manager. "+
+			"Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&secureMetrics, "metrics-secure", true,
+		"If set, the metrics endpoint is served securely via HTTPS. Use --metrics-secure=false to use HTTP instead.")
+	flag.StringVar(&webhookCertPath, "webhook-cert-path", "/tmp/kube-apiproxy/certs", "The directory that contains the webhook certificate.")
+	flag.StringVar(&webhookCertName, "webhook-cert-name", "tls.crt", "The name of the webhook certificate file.")
+	flag.StringVar(&webhookCertKey, "webhook-cert-key", "tls.key", "The name of the webhook key file.")
+	flag.StringVar(&metricsCertPath, "metrics-cert-path", "",
+		"The directory that contains the metrics server certificate.")
+	flag.StringVar(&metricsCertName, "metrics-cert-name", "tls.crt", "The name of the metrics server certificate file.")
+	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
+	flag.BoolVar(&enableHTTP2, "enable-http2", false,
+		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	opts := zap.Options{
+		Development: true,
+	}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	k8sConfig := ctrl.GetConfigOrDie()
+	ctx := ctrl.SetupSignalHandler()
+
+	// if the enable-http2 flag is false (the default), http/2 should be disabled
+	// due to its vulnerabilities. More specifically, disabling http/2 will
+	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
+	// Rapid Reset CVEs. For more information see:
+	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
+	// - https://github.com/advisories/GHSA-4374-p667-p6c8
+	disableHTTP2 := func(c *tls.Config) {
+		setupLog.Info("disabling http/2")
+		c.NextProtos = []string{"http/1.1"}
+	}
+
+	if !enableHTTP2 {
+		tlsOpts = append(tlsOpts, disableHTTP2)
+	}
+
+	// Create watchers for metrics and webhooks certificates
+	var metricsCertWatcher, webhookCertWatcher *certwatcher.CertWatcher
+
+	// Initial webhook TLS options
+	webhookTLSOpts := tlsOpts
+
+	if len(webhookCertPath) > 0 {
+		setupLog.Info("Initializing webhook certificate watcher using provided certificates",
+			"webhook-cert-path", webhookCertPath, "webhook-cert-name", webhookCertName, "webhook-cert-key", webhookCertKey)
+
+		var err error
+		webhookCertWatcher, err = certwatcher.New(
+			filepath.Join(webhookCertPath, webhookCertName),
+			filepath.Join(webhookCertPath, webhookCertKey),
+		)
+		if err != nil {
+			setupLog.Error(err, "Failed to initialize webhook certificate watcher")
+			os.Exit(1)
+		}
+
+		webhookTLSOpts = append(webhookTLSOpts, func(config *tls.Config) {
+			config.GetCertificate = webhookCertWatcher.GetCertificate
+		})
+	}
+
+	webhookServer := webhook.NewServer(webhook.Options{
+		Port:    6443,
+		TLSOpts: webhookTLSOpts,
+	})
+
+	// Metrics endpoint is enabled in 'config/default/kustomization.yaml'. The Metrics options configure the server.
+	// More info:
+	// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.2/pkg/metrics/server
+	// - https://book.kubebuilder.io/reference/metrics.html
+	metricsServerOptions := metricsserver.Options{
+		BindAddress:   metricsAddr,
+		SecureServing: secureMetrics,
+		TLSOpts:       tlsOpts,
+	}
+
+	if secureMetrics {
+		// FilterProvider is used to protect the metrics endpoint with authn/authz.
+		// These configurations ensure that only authorized users and service accounts
+		// can access the metrics endpoint. The RBAC are configured in 'config/rbac/kustomization.yaml'. More info:
+		// https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.20.2/pkg/metrics/filters#WithAuthenticationAndAuthorization
+		metricsServerOptions.FilterProvider = filters.WithAuthenticationAndAuthorization
+	}
+
+	// If the certificate is not specified, controller-runtime will automatically
+	// generate self-signed certificates for the metrics server. While convenient for development and testing,
+	// this setup is not recommended for production.
+	//
+	// TODO(user): If you enable certManager, uncomment the following lines:
+	// - [METRICS-WITH-CERTS] at config/default/kustomization.yaml to generate and use certificates
+	// managed by cert-manager for the metrics server.
+	// - [PROMETHEUS-WITH-CERTS] at config/prometheus/kustomization.yaml for TLS certification.
+	if len(metricsCertPath) > 0 {
+		setupLog.Info("Initializing metrics certificate watcher using provided certificates",
+			"metrics-cert-path", metricsCertPath, "metrics-cert-name", metricsCertName, "metrics-cert-key", metricsCertKey)
+
+		var err error
+		metricsCertWatcher, err = certwatcher.New(
+			filepath.Join(metricsCertPath, metricsCertName),
+			filepath.Join(metricsCertPath, metricsCertKey),
+		)
+		if err != nil {
+			setupLog.Error(err, "to initialize metrics certificate watcher", "error", err)
+			os.Exit(1)
+		}
+
+		metricsServerOptions.TLSOpts = append(metricsServerOptions.TLSOpts, func(config *tls.Config) {
+			config.GetCertificate = metricsCertWatcher.GetCertificate
+		})
+	}
+
+	mgr, err := ctrl.NewManager(k8sConfig, ctrl.Options{
+		Scheme:                 scheme.Get(),
+		Metrics:                metricsServerOptions,
+		WebhookServer:          webhookServer,
+		HealthProbeBindAddress: probeAddr,
+		LeaderElection:         enableLeaderElection,
+		LeaderElectionID:       "06f3a2a9.fcp.funccloud.com",
+		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
+		// when the Manager ends. This requires the binary to immediately end when the
+		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
+		// speeds up voluntary leader transitions as the new leader don't have to wait
+		// LeaseDuration time first.
+		//
+		// In the default scaffold provided, the program ends immediately after
+		// the manager stops, so would be fine to enable this option. However,
+		// if you are doing or is intended to do any operation such as perform cleanups
+		// after the manager stops then its usage might be unsafe.
+		// LeaderElectionReleaseOnCancel: true,
+	})
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	if metricsCertWatcher != nil {
+		setupLog.Info("Adding metrics certificate watcher to manager")
+		if err := mgr.Add(metricsCertWatcher); err != nil {
+			setupLog.Error(err, "unable to add metrics certificate watcher to manager")
+			os.Exit(1)
+		}
+	}
+
+	if webhookCertWatcher != nil {
+		setupLog.Info("Adding webhook certificate watcher to manager")
+		if err := mgr.Add(webhookCertWatcher); err != nil {
+			setupLog.Error(err, "unable to add webhook certificate watcher to manager")
+			os.Exit(1)
+		}
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
+	}
+
+	if err := tokenreview.SetupTokenReviewWebhookWithManager(mgr, userInfoEndpoint); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "TokenReview")
+	}
+
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctx); err != nil {
+		setupLog.Error(err, "problem running manager")
+		os.Exit(1)
+	}
+}

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -30,6 +30,7 @@ resources:
 - ../manager
 - ../webhook
 - ../certmanager
+- ../kube-authenticator
 - metrics_service.yaml
 - ../network-policy
 
@@ -210,9 +211,45 @@ replacements:
       index: 1
     select:
       kind: MutatingWebhookConfiguration
+# Add replacements for kube-authenticator certificate
+- source:
+    kind: Service
+    name: kube-authenticator-webhook-service # This should match the service name for kube-authenticator
+    version: v1
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Certificate
+      name: kube-authenticator-serving-cert # This should match the certificate name
+      group: cert-manager.io
+    fieldPaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: .
+      index: 0 # Replace KUBE_AUTHENTICATOR_SERVICE_NAME placeholder
+- source:
+    kind: Service
+    name: kube-authenticator-webhook-service # This should match the service name for kube-authenticator
+    version: v1
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: Certificate
+      name: kube-authenticator-serving-cert # This should match the certificate name
+      group: cert-manager.io
+    fieldPaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: .
+      index: 1 # Replace KUBE_AUTHENTICATOR_SERVICE_NAMESPACE placeholder
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: manager
   newName: ghcr.io/funccloud/fcp/manager
+  newTag: latest
+- name: kube-authenticator
+  newName: ghcr.io/funccloud/fcp/kube-authenticator
   newTag: latest

--- a/config/kube-authenticator/kube-authenticator-certificate.yaml
+++ b/config/kube-authenticator/kube-authenticator-certificate.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: kube-authenticator-serving-cert
+  namespace: system # This will be overridden by the namespace in config/default/kustomization.yaml
+spec:
+  secretName: kube-authenticator-webhook-certs
+  dnsNames:
+  # KUBE_AUTHENTICATOR_SERVICE_NAME and KUBE_AUTHENTICATOR_SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
+  - KUBE_AUTHENTICATOR_SERVICE_NAME.KUBE_AUTHENTICATOR_SERVICE_NAMESPACE.svc
+  - KUBE_AUTHENTICATOR_SERVICE_NAME.KUBE_AUTHENTICATOR_SERVICE_NAMESPACE.svc.cluster.local
+  - servers.fcp.funccloud.com
+  - 127.0.0.1.sslip.io
+  issuerRef:
+    name: selfsigned-issuer # Assumes this issuer exists in the target namespace
+    kind: Issuer
+    group: cert-manager.io

--- a/config/kube-authenticator/kube-authenticator.yaml
+++ b/config/kube-authenticator/kube-authenticator.yaml
@@ -1,0 +1,102 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-authenticator-sa
+  namespace: system # Assuming the same namespace as other components
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-authenticator
+  namespace: system # Assuming the same namespace
+  labels:
+    app.kubernetes.io/name: kube-authenticator
+    app.kubernetes.io/component: webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kube-authenticator
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kube-authenticator
+    spec:
+      serviceAccountName: kube-authenticator-sa
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: authenticator
+        image: kube-authenticator:latest # Placeholder, will be updated by kustomize
+        command:
+        - /kube-authenticator
+        args:
+        - --webhook-cert-path=/tmp/kube-authenticator/certs
+        - --webhook-cert-name=tls.crt
+        - --webhook-cert-key=tls.key
+        - --metrics-bind-address=:8080 # Or 0 to disable if not needed via kustomize patch
+        - --health-probe-bind-address=:8081
+        # - --userinfo-endpoint=YOUR_USERINFO_ENDPOINT # This should be configured
+        ports:
+        - containerPort: 6443
+          name: webhook
+          protocol: TCP
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        - containerPort: 8081
+          name: health
+          protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - "ALL"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: health # Corresponds to containerPort 8081
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: health # Corresponds to containerPort 8081
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        volumeMounts:
+        - name: webhook-authenticator-certs
+          mountPath: /tmp/kube-authenticator/certs
+          readOnly: true
+        resources:
+          limits:
+            cpu: 200m
+            memory: 128Mi
+          requests:
+            cpu: 100m
+            memory: 64Mi
+      volumes:
+      - name: webhook-authenticator-certs
+        secret:
+          secretName: kube-authenticator-webhook-certs # This secret needs to be created (e.g., by cert-manager)
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-authenticator-webhook-service
+  namespace: system # Assuming the same namespace
+  labels:
+    app.kubernetes.io/name: kube-authenticator
+spec:
+  selector:
+    app.kubernetes.io/name: kube-authenticator
+  type: LoadBalancer
+  ports:
+  - port: 6443 # Standard webhook port, targets containerPort 6443
+    targetPort: webhook
+    nodePort: 31643
+    protocol: TCP

--- a/config/kube-authenticator/kube-authenticator.yaml
+++ b/config/kube-authenticator/kube-authenticator.yaml
@@ -30,6 +30,9 @@ spec:
       containers:
       - name: authenticator
         image: kube-authenticator:latest # Placeholder, will be updated by kustomize
+        env:
+        - name: USERINFO_ENDPOINT
+          value: "https://id.funccloud.com/userinfo" # Default or placeholder value
         command:
         - /kube-authenticator
         args:
@@ -38,7 +41,6 @@ spec:
         - --webhook-cert-key=tls.key
         - --metrics-bind-address=:8080 # Or 0 to disable if not needed via kustomize patch
         - --health-probe-bind-address=:8081
-        # - --userinfo-endpoint=YOUR_USERINFO_ENDPOINT # This should be configured
         ports:
         - containerPort: 6443
           name: webhook

--- a/config/kube-authenticator/kustomization.yaml
+++ b/config/kube-authenticator/kustomization.yaml
@@ -1,0 +1,10 @@
+resources:
+- kube-authenticator.yaml
+- kube-authenticator-certificate.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: kube-authenticator # This should match the image name in the deployment
+  newName: ghcr.io/funccloud/fcp/kube-authenticator # Replace with your actual image path
+  newTag: latest # Replace with your actual image tag

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -13,3 +13,6 @@ subjects:
 - kind: ServiceAccount
   name: controller-manager
   namespace: system
+- kind: ServiceAccount
+  name: kube-authenticator-sa
+  namespace: system

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	knative.dev/pkg v0.0.0-20250424013628-d5e74d29daa3
 	knative.dev/serving v0.45.0
 	sigs.k8s.io/controller-runtime v0.20.4
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -107,5 +108,4 @@ require (
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.31.0 // indirect
 	sigs.k8s.io/json v0.0.0-20241014173422-cfa47c3a1cc8 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.5.0 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/hack/kind-config.yaml
+++ b/hack/kind-config.yaml
@@ -9,3 +9,5 @@ nodes:
     hostPort: 80
   - containerPort: 31443
     hostPort: 443
+  - containerPort: 31643
+    hostPort: 6443

--- a/internal/resource/fcp/kube_authenticator.go
+++ b/internal/resource/fcp/kube_authenticator.go
@@ -1,0 +1,41 @@
+package fcp
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	kubeAuthenticatorServiceName      = "fcp-kube-authenticator-webhook-service"
+	kubeAuthenticatorServiceNamespace = "fcp-system"
+)
+
+func SetupKubeAuthenticator(ctx context.Context, k8sClient client.Client, l logr.Logger, onKind bool) error {
+	if onKind {
+		// Change service type to NodePort
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      kubeAuthenticatorServiceName,
+				Namespace: kubeAuthenticatorServiceNamespace,
+			},
+			Spec: corev1.ServiceSpec{},
+		}
+		result, err := controllerutil.CreateOrUpdate(ctx, k8sClient, svc, func() error {
+			svc.Spec.Type = corev1.ServiceTypeNodePort
+			return nil
+		})
+		if err != nil {
+			l.Error(err, "Failed to create or update kube-authenticator service")
+			return err
+		}
+		if result != controllerutil.OperationResultNone {
+			l.Info("Kube-authenticator service created or updated", "result", result)
+		}
+	}
+	return nil
+}

--- a/internal/resource/resource.go
+++ b/internal/resource/resource.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"go.funccloud.dev/fcp/internal/resource/certmanager"
+	"go.funccloud.dev/fcp/internal/resource/fcp"
 	"go.funccloud.dev/fcp/internal/resource/kind"
 	"go.funccloud.dev/fcp/internal/resource/knative"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,6 +40,10 @@ func CheckOrInstallVersion(ctx context.Context, domain string, k8sClient client.
 		log.Error(err, "Error checking or installing Knative")
 		return err
 	}
-
+	err = fcp.SetupKubeAuthenticator(ctx, k8sClient, log, onKind)
+	if err != nil {
+		log.Error(err, "Error setting up kube-authenticator")
+		return err
+	}
 	return nil
 }

--- a/internal/webhook/tokenreview/tokenreview_webhook.go
+++ b/internal/webhook/tokenreview/tokenreview_webhook.go
@@ -1,0 +1,63 @@
+package tokenreview
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+
+	authv1 "k8s.io/api/authentication/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/authentication"
+	"sigs.k8s.io/yaml"
+)
+
+func SetupTokenReviewWebhookWithManager(mgr ctrl.Manager, userInfoEndpoint string) error {
+	if userInfoEndpoint == "" {
+		return fmt.Errorf("userinfo-endpoint is required")
+	}
+	mgr.GetWebhookServer().Register("/", &authentication.Webhook{
+		Handler: &Authenticator{
+			UserInfoEndpoint: userInfoEndpoint,
+		},
+	})
+	return nil
+}
+
+// Authenticator validates tokenreviews
+type Authenticator struct {
+	// UserInfoEndpoint is the endpoint to use for authentication.
+	UserInfoEndpoint string
+}
+
+// authenticator admits a request by the token.
+func (a *Authenticator) Handle(ctx context.Context, r authentication.Request) authentication.Response {
+	l := log.FromContext(ctx)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.UserInfoEndpoint, nil)
+	if err != nil {
+		return authentication.Errored(err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", r.Spec.Token))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return authentication.Errored(err)
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			l.Error(closeErr, "failed to close response body")
+		}
+	}()
+	byt, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return authentication.Errored(err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return authentication.Unauthenticated(string(byt), authv1.UserInfo{})
+	}
+	userInfo := authv1.UserInfo{}
+	if err := yaml.Unmarshal(byt, &userInfo); err != nil {
+		return authentication.Errored(err)
+	}
+	return authentication.Authenticated("", userInfo)
+}

--- a/internal/webhook/tokenreview/tokenreview_webhook.go
+++ b/internal/webhook/tokenreview/tokenreview_webhook.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	authv1 "k8s.io/api/authentication/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -33,13 +34,16 @@ type Authenticator struct {
 
 // authenticator admits a request by the token.
 func (a *Authenticator) Handle(ctx context.Context, r authentication.Request) authentication.Response {
+	client := http.Client{
+		Timeout: 10 * time.Second,
+	}
 	l := log.FromContext(ctx)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.UserInfoEndpoint, nil)
 	if err != nil {
 		return authentication.Errored(err)
 	}
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", r.Spec.Token))
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return authentication.Errored(err)
 	}

--- a/internal/webhook/tokenreview/tokenreview_webhook_test.go
+++ b/internal/webhook/tokenreview/tokenreview_webhook_test.go
@@ -56,7 +56,7 @@ var _ = Describe("TokenReview Webhook", func() {
 			Expect(resp.Status.User.UID).To(BeEmpty())
 			Expect(resp.Status.User.Groups).To(BeEmpty())
 			Expect(resp.Status.User.Extra).To(BeEmpty())
-			Expect(resp.Status.Error).To(Equal("missing token"))
+			Expect(resp.Status.Error).To(Equal("missing token\n"))
 		})
 
 		It("should fail when token is invalid", func() {
@@ -72,7 +72,7 @@ var _ = Describe("TokenReview Webhook", func() {
 			Expect(resp.Status.User.UID).To(BeEmpty())
 			Expect(resp.Status.User.Groups).To(BeEmpty())
 			Expect(resp.Status.User.Extra).To(BeEmpty())
-			Expect(resp.Status.Error).To(Equal("invalid token"))
+			Expect(resp.Status.Error).To(Equal("invalid token\n"))
 		})
 	})
 })

--- a/internal/webhook/tokenreview/tokenreview_webhook_test.go
+++ b/internal/webhook/tokenreview/tokenreview_webhook_test.go
@@ -63,7 +63,7 @@ var _ = Describe("TokenReview Webhook", func() {
 			resp := authenticator.Handle(ctx, authentication.Request{
 				TokenReview: authv1.TokenReview{
 					Spec: authv1.TokenReviewSpec{
-						Token: "",
+						Token: "invalid-token",
 					},
 				},
 			})

--- a/internal/webhook/tokenreview/tokenreview_webhook_test.go
+++ b/internal/webhook/tokenreview/tokenreview_webhook_test.go
@@ -1,0 +1,78 @@
+package tokenreview
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	authv1 "k8s.io/api/authentication/v1"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/authentication"
+)
+
+var (
+	authenticator *Authenticator
+)
+
+var _ = Describe("TokenReview Webhook", func() {
+	BeforeEach(func() {
+		authenticator = &Authenticator{
+			UserInfoEndpoint: s.URL,
+		}
+	})
+
+	AfterEach(func() {
+		// Add teardown logic here
+	})
+
+	Context("when handling a valid request", func() {
+		It("should succeed", func() {
+			resp := authenticator.Handle(ctx, authentication.Request{
+				TokenReview: authv1.TokenReview{
+					Spec: authv1.TokenReviewSpec{
+						Token: "test-token",
+					},
+				},
+			})
+			Expect(resp.Status.Authenticated).To(BeTrue())
+			Expect(resp.Status.User.Username).To(Equal("test-user"))
+			Expect(resp.Status.User.UID).To(Equal("test-uid"))
+			Expect(resp.Status.User.Groups).To(ContainElement("group1"))
+			Expect(resp.Status.User.Groups).To(ContainElement("group2"))
+			Expect(resp.Status.User.Extra["key"]).To(ContainElement("value1"))
+			Expect(resp.Status.User.Extra["key"]).To(ContainElement("value2"))
+
+		})
+	})
+
+	Context("when handling an invalid request", func() {
+		It("should fail when token is empty", func() {
+			resp := authenticator.Handle(ctx, authentication.Request{
+				TokenReview: authv1.TokenReview{
+					Spec: authv1.TokenReviewSpec{
+						Token: "",
+					},
+				},
+			})
+			Expect(resp.Status.Authenticated).To(BeFalse())
+			Expect(resp.Status.User.Username).To(BeEmpty())
+			Expect(resp.Status.User.UID).To(BeEmpty())
+			Expect(resp.Status.User.Groups).To(BeEmpty())
+			Expect(resp.Status.User.Extra).To(BeEmpty())
+			Expect(resp.Status.Error).To(Equal("missing token"))
+		})
+
+		It("should fail when token is invalid", func() {
+			resp := authenticator.Handle(ctx, authentication.Request{
+				TokenReview: authv1.TokenReview{
+					Spec: authv1.TokenReviewSpec{
+						Token: "",
+					},
+				},
+			})
+			Expect(resp.Status.Authenticated).To(BeFalse())
+			Expect(resp.Status.User.Username).To(BeEmpty())
+			Expect(resp.Status.User.UID).To(BeEmpty())
+			Expect(resp.Status.User.Groups).To(BeEmpty())
+			Expect(resp.Status.User.Extra).To(BeEmpty())
+			Expect(resp.Status.Error).To(Equal("invalid token"))
+		})
+	})
+})

--- a/internal/webhook/tokenreview/webhook_suite_test.go
+++ b/internal/webhook/tokenreview/webhook_suite_test.go
@@ -58,6 +58,7 @@ var (
 	cfg       *rest.Config
 	testEnv   *envtest.Environment
 	s         *httptest.Server
+	err       error
 )
 
 func TestAPIs(t *testing.T) {
@@ -85,7 +86,7 @@ var _ = BeforeSuite(func() {
 	}
 
 	// cfg is defined in this file globally.
-	cfg, err := testEnv.Start()
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 

--- a/internal/webhook/tokenreview/webhook_suite_test.go
+++ b/internal/webhook/tokenreview/webhook_suite_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tokenreview
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+
+	// +kubebuilder:scaffold:imports
+
+	authv1 "k8s.io/api/authentication/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
+	s         *httptest.Server
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "TokenReview Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		ErrorIfCRDPathMissing: true, // No CRDs needed for this webhook, but keep consistency
+
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")}, // Adjust if needed for tokenreview specific webhook config
+		},
+	}
+
+	var err error
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	// Add necessary schemes
+	err = admissionv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = authenticationv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// start webhook server using Manager.
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"}, // Disable metrics for tests
+	})
+	Expect(err).NotTo(HaveOccurred())
+	s = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		if token == "" {
+			http.Error(w, "missing token", http.StatusUnauthorized)
+			return
+		}
+		if token != "Bearer test-token" {
+			http.Error(w, "invalid token", http.StatusUnauthorized)
+			return
+		}
+		u := authv1.UserInfo{
+			Username: "test-user",
+			UID:      "test-uid",
+			Groups:   []string{"group1", "group2"},
+			Extra:    map[string]authv1.ExtraValue{"key": {"value1", "value2"}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		if err := json.NewEncoder(w).Encode(u); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	}))
+	err = SetupTokenReviewWebhookWithManager(mgr, s.URL) // Register the TokenReview webhook
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:webhook
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// wait for the webhook server to get ready.
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		return conn.Close()
+	}).Should(Succeed())
+
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	s.Close()
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
+// ENVTEST-based tests depend on specific binaries, usually located in paths set by
+// controller-runtime. When running tests directly (e.g., via an IDE) without using
+// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
+//
+// This function streamlines the process by finding the required binaries, similar to
+// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
+// properly set up, run 'make setup-envtest' beforehand.
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			// Set the BinaryAssetsDirectory if found
+			testEnv.BinaryAssetsDirectory = filepath.Join(basePath, entry.Name())
+			return testEnv.BinaryAssetsDirectory
+		}
+	}
+	logf.Log.Info("envtest binary directory not found, KUBEBUILDER_ASSETS might need to be set", "path", basePath)
+	return ""
+}
+
+// Ensure getFirstFoundEnvTestBinaryDir is called early
+var _ = func() string {
+	// Call this during package initialization to set testEnv.BinaryAssetsDirectory
+	// before BeforeSuite potentially uses it (though Start() implicitly handles this).
+	// This makes the logic clearer.
+	return getFirstFoundEnvTestBinaryDir()
+}()

--- a/internal/webhook/tokenreview/webhook_suite_test.go
+++ b/internal/webhook/tokenreview/webhook_suite_test.go
@@ -26,6 +26,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -113,7 +114,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	s = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := r.Header.Get("Authorization")
-		if token == "Bearer " {
+		token = strings.TrimSpace(token)
+		if token == "Bearer" {
 			http.Error(w, "missing token", http.StatusUnauthorized)
 			return
 		}

--- a/internal/webhook/tokenreview/webhook_suite_test.go
+++ b/internal/webhook/tokenreview/webhook_suite_test.go
@@ -113,7 +113,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	s = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		token := r.Header.Get("Authorization")
-		if token == "" {
+		if token == "Bearer " {
 			http.Error(w, "missing token", http.StatusUnauthorized)
 			return
 		}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -39,10 +39,12 @@ var (
 
 	// projectImage is the name of the image which will be build and loaded
 	// with the code source changes to be tested.
-	projectRegistry = "example.com"
-	projectApp      = "manager"
-	projectVersion  = "v0.0.1"
-	projectImage    = fmt.Sprintf("%s/%s:%s", projectRegistry, projectApp, projectVersion)
+	projectRegistry  = "example.com"
+	projectApp       = "manager"
+	projectAuth      = "kube-authenticator"
+	projectVersion   = "v0.0.1"
+	projectImage     = fmt.Sprintf("%s/%s:%s", projectRegistry, projectApp, projectVersion)
+	projectImageAuth = fmt.Sprintf("%s/%s:%s", projectRegistry, projectAuth, projectVersion)
 )
 
 // TestE2E runs the end-to-end (e2e) test suite for the project. These tests execute in an isolated,
@@ -57,7 +59,7 @@ func TestE2E(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	By("building the manager(Operator) image")
-	cmd := exec.Command("make", "docker-build-manager", fmt.Sprintf("REGISTRY=%s", projectRegistry), fmt.Sprintf("VERSION=%s", projectVersion))
+	cmd := exec.Command("make", "docker-build", fmt.Sprintf("REGISTRY=%s", projectRegistry), fmt.Sprintf("VERSION=%s", projectVersion))
 	_, err := utils.Run(cmd)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to build the manager(Operator) image")
 
@@ -66,6 +68,8 @@ var _ = BeforeSuite(func() {
 	By("loading the manager(Operator) image on Kind")
 	err = utils.LoadImageToKindClusterWithName(projectImage)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the manager(Operator) image into Kind")
+	err = utils.LoadImageToKindClusterWithName(projectImageAuth)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred(), "Failed to load the kube-authenticator image into Kind")
 
 	// The tests-e2e are intended to run on a temporary cluster that is created and destroyed for testing.
 	// To prevent errors when tests run in environments with CertManager already installed,


### PR DESCRIPTION
This pull request introduces a new Kubernetes webhook for token review authentication, along with supporting infrastructure and tests. Key changes include the implementation of the webhook, integration with the manager, and test coverage for the new functionality.

### Webhook Implementation:
* Added a new `tokenreview` package with an `Authenticator` struct and a `SetupTokenReviewWebhookWithManager` function to handle token review authentication using a user info endpoint (`internal/webhook/tokenreview/tokenreview_webhook.go`).

### Manager and Main Application:
* Created the `main.go` file to initialize the Kubernetes controller manager, configure the webhook server, and manage TLS certificates. This includes a new `--userinfo-endpoint` flag for the webhook (`cmd/kube-authenticator/main.go`).

### Dependency Updates:
* Added `sigs.k8s.io/yaml` as a direct dependency in `go.mod` to support YAML unmarshalling in the webhook (`go.mod`). [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R21) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L110)

### Test Suite:
* Introduced unit tests for the `Authenticator` in `tokenreview_webhook_test.go`, covering valid and invalid token scenarios (`internal/webhook/tokenreview/tokenreview_webhook_test.go`).
* Added integration tests in `webhook_suite_test.go` to validate the end-to-end functionality of the webhook, including a mock user info endpoint (`internal/webhook/tokenreview/webhook_suite_test.go`).